### PR TITLE
Add columns order

### DIFF
--- a/app/Http/Controllers/Api/V1/Board/ColumnController.php
+++ b/app/Http/Controllers/Api/V1/Board/ColumnController.php
@@ -32,7 +32,7 @@ class ColumnController extends Controller
     {
         $column = new Column($request->validated());
         $column->board()->associate($board);
-        $column->save();
+        $column->moveTo($request->after_column);
 
         return (new BoardColumnResource($column))->response()->setStatusCode(201);
     }

--- a/app/Http/Controllers/Api/V1/Card/CardController.php
+++ b/app/Http/Controllers/Api/V1/Card/CardController.php
@@ -41,7 +41,7 @@ class CardController extends Controller
     {
         $card->moveTo($request->after);
 
-        return new CardResource($card);
+        return response('', 204);
     }
 
     public function move(MoveCardRequest $request, Card $card, Column $column)

--- a/app/Http/Controllers/Api/V1/Column/ColumnController.php
+++ b/app/Http/Controllers/Api/V1/Column/ColumnController.php
@@ -39,7 +39,7 @@ class ColumnController extends Controller
     {
         $column->moveTo($request->after);
 
-        return new ColumnResource($column);
+        return response('', 204);
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/Column/ColumnController.php
+++ b/app/Http/Controllers/Api/V1/Column/ColumnController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1\Column;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\Column\OrderColumnRequest;
 use App\Http\Requests\Api\V1\Column\UpdateColumnRequest;
 use App\Http\Resources\V1\Column\ColumnResource;
 use App\Models\Column;
@@ -30,6 +31,13 @@ class ColumnController extends Controller
     public function update(UpdateColumnRequest $request, Column $column)
     {
         $column->update($request->validated());
+
+        return new ColumnResource($column);
+    }
+
+    public function order(OrderColumnRequest $request, Column $column)
+    {
+        $column->moveTo($request->after);
 
         return new ColumnResource($column);
     }

--- a/app/Http/Requests/Api/V1/Board/StoreColumnRequest.php
+++ b/app/Http/Requests/Api/V1/Board/StoreColumnRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Api\V1\Board;
 
+use App\Rules\Api\ColumnInSameBoard;
 use App\Rules\Api\MaxColumnsPerBoard;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -16,6 +17,8 @@ class StoreColumnRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
+            'after_column' => ['nullable', 'integer', 'min:0', new ColumnInSameBoard($this, $this->route('board'))],
+
             'board' => [new MaxColumnsPerBoard($this->route('board'))],
         ];
     }

--- a/app/Http/Requests/Api/V1/Column/OrderColumnRequest.php
+++ b/app/Http/Requests/Api/V1/Column/OrderColumnRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Api\V1\Column;
+
+use App\Rules\Api\ColumnInSameBoard;
+use Illuminate\Foundation\Http\FormRequest;
+
+class OrderColumnRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'after' => ['present', 'integer', 'min:0', new ColumnInSameBoard($this, $this->route('column')->board)],
+        ];
+    }
+}

--- a/app/Models/Card.php
+++ b/app/Models/Card.php
@@ -13,7 +13,7 @@ use Znck\Eloquent\Traits\BelongsToThrough;
  * @property int $id
  * @property string $name
  * @property string|null $description
- * @property int|null $order
+ * @property double|null $order
  * @property-read \App\Models\Board $column
  * @property int $column_id
  * @property \Illuminate\Support\Carbon|null $created_at

--- a/app/Models/Column.php
+++ b/app/Models/Column.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\HasOrder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Znck\Eloquent\Traits\BelongsToThrough;
@@ -11,6 +12,7 @@ use Znck\Eloquent\Traits\BelongsToThrough;
  *
  * @property int $id
  * @property string $name
+ * @property double|null $order
  * @property-read \App\Models\Board $board
  * @property int $board_id
  * @property \Illuminate\Support\Carbon|null $created_at
@@ -26,11 +28,16 @@ use Znck\Eloquent\Traits\BelongsToThrough;
  */
 class Column extends Model
 {
-    use HasFactory, BelongsToThrough;
+    use HasFactory, BelongsToThrough, HasOrder;
 
     protected $fillable = [
         'name',
     ];
+
+    public function getOrderQuery($query)
+    {
+        return $query->where('board_id', $this->board_id);
+    }
 
     /*
     |-------------------------------------------------------------

--- a/app/Rules/Api/ColumnInSameBoard.php
+++ b/app/Rules/Api/ColumnInSameBoard.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Rules\Api;
+
+use App\Models\Board;
+use App\Models\Column;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Http\Request;
+
+class ColumnInSameBoard implements Rule
+{
+    protected $request;
+
+    protected $board;
+
+    protected $attribute;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct(Request $request, Board $board)
+    {
+        $this->request = $request;
+        $this->board = $board;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        if ($value == 0) {
+            return true;
+        }
+
+        $this->attribute = $attribute;
+
+        $column = Column::where('board_id', $this->board->id)->find((int)$value);
+
+        if ($column == null) {
+            return false;
+        }
+
+        $this->request->merge([$attribute => $column]);
+
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return trans('validation.exists', ['attribute' => $this->attribute]);
+    }
+}

--- a/database/factories/ColumnFactory.php
+++ b/database/factories/ColumnFactory.php
@@ -15,7 +15,15 @@ class ColumnFactory extends Factory
     {
         return [
             'name' => $this->faker->words(2, true),
+            'order' => 1,
         ];
+    }
+
+    public function order($order)
+    {
+        return $this->state([
+            'order' => $order,
+        ]);
     }
 
     /** Setup board for the column.

--- a/database/migrations/2022_03_19_101149_add_order_column_to_columns_table.php
+++ b/database/migrations/2022_03_19_101149_add_order_column_to_columns_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddOrderColumnToColumnsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('columns', function (Blueprint $table) {
+            $table->decimal('order', 6, 1)->nullable()->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('columns', function (Blueprint $table) {
+            $table->dropColumn('order');
+        });
+    }
+}

--- a/routes/api-v1.php
+++ b/routes/api-v1.php
@@ -193,6 +193,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             Route::post('/', [Column\CardController::class, 'store'])->can('create', [CardModel::class, 'column']);
         });
 
+        Route::post('/{column}/order', [Column\ColumnController::class, 'order'])->can('update', 'column');
         Route::get('/{column}', [Column\ColumnController::class, 'show'])->can('view', 'column');
         Route::patch('/{column}', [Column\ColumnController::class, 'update'])->can('update', 'column');
         Route::delete('/{column}', [Column\ColumnController::class, 'destroy'])->can('delete', 'column');

--- a/tests/Feature/Api/V1/Card/CardControllerTest.php
+++ b/tests/Feature/Api/V1/Card/CardControllerTest.php
@@ -290,64 +290,6 @@ class CardControllerTest extends TestCase
         $this->assertEquals(3, $cards[2]->order);
         $this->assertEquals(4, $cards[0]->order);
     }
-    public function test_order_not_recalculated_with_inconsistent_order_on_ordering_to_up()
-    {
-        $team = Team::factory()->create();
-        $project = Project::factory()->team($team)->create();
-        $board = Board::factory()->project($project)->create();
-        $column = Column::factory()->board($board)->create();
-
-        $cards = Card::factory(2)->column($column)
-        ->state(new Sequence(
-            ['order' => 1],
-            ['order' => 3],
-        ))->create();
-        $card = Card::factory()->column($column)->order(4)->create();
-
-        $user = User::factory()->hasAttached($team)->create();
-        Sanctum::actingAs($user);
-
-        $response = $this->postJson('/api/v1/cards/' . $card->id . '/order', ['after' => $cards[0]->id]);
-
-        $card->refresh();
-        $cards = $cards->fresh();
-
-        $response
-            ->assertOk()
-            ->assertJson((new CardResource($card))->response()->getData(true));
-        $this->assertEquals(1, $cards[0]->order);
-        $this->assertEquals(2, $card->order);
-        $this->assertEquals(3, $cards[1]->order);
-    }
-    public function test_order_not_recalculated_with_inconsistent_order_on_ordering_to_bottom()
-    {
-        $team = Team::factory()->create();
-        $project = Project::factory()->team($team)->create();
-        $board = Board::factory()->project($project)->create();
-        $column = Column::factory()->board($board)->create();
-
-        $card = Card::factory()->column($column)->order(1)->create();
-        $cards = Card::factory(2)->column($column)
-        ->state(new Sequence(
-            ['order' => 2],
-            ['order' => 4],
-        ))->create();
-
-        $user = User::factory()->hasAttached($team)->create();
-        Sanctum::actingAs($user);
-
-        $response = $this->postJson('/api/v1/cards/' . $card->id . '/order', ['after' => $cards[0]->id]);
-
-        $card->refresh();
-        $cards = $cards->fresh();
-
-        $response
-            ->assertOk()
-            ->assertJson((new CardResource($card))->response()->getData(true));
-        $this->assertEquals(1, $cards[0]->order);
-        $this->assertEquals(2, $card->order);
-        $this->assertEquals(3, $cards[1]->order);
-    }
 
     public function test_cant_move_without_permissions()
     {

--- a/tests/Feature/Api/V1/Card/CardControllerTest.php
+++ b/tests/Feature/Api/V1/Card/CardControllerTest.php
@@ -150,13 +150,12 @@ class CardControllerTest extends TestCase
             ->assertUnprocessable()
             ->assertJsonValidationErrors(['after' => 'The selected after is invalid.']);
     }
-    public function test_can_change_order_to_up()
+    public function test_can_change_order()
     {
         $team = Team::factory()->create();
         $project = Project::factory()->team($team)->create();
         $board = Board::factory()->project($project)->create();
         $column = Column::factory()->board($board)->create();
-
         $cards = Card::factory(3)->column($column)
             ->state(new Sequence(
                 ['order' => 1],
@@ -168,127 +167,41 @@ class CardControllerTest extends TestCase
         $user = User::factory()->hasAttached($team)->create();
         Sanctum::actingAs($user);
 
+        // Move to up dirrection
         $response = $this->postJson('/api/v1/cards/' . $card->id . '/order', ['after' => $cards[1]->id]);
 
         $card->refresh();
         $cards = $cards->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new CardResource($card))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $cards[0]->order);
         $this->assertEquals(2, $cards[1]->order);
         $this->assertEquals(3, $card->order);
         $this->assertEquals(4, $cards[2]->order);
 
+        // First position
         $response = $this->postJson('/api/v1/cards/' . $card->id . '/order', ['after' => 0]);
 
         $card->refresh();
         $cards = $cards->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new CardResource($card))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $card->order);
         $this->assertEquals(2, $cards[0]->order);
         $this->assertEquals(3, $cards[1]->order);
         $this->assertEquals(4, $cards[2]->order);
 
-        $response = $this->postJson('/api/v1/cards/' . $cards[1]->id . '/order', ['after' => 0]);
-
-        $card->refresh();
-        $cards = $cards->fresh();
-
-        $response
-            ->assertOk()
-            ->assertJson((new CardResource($cards[1]))->response()->getData(true));
-        $this->assertEquals(1, $cards[1]->order);
-        $this->assertEquals(2, $card->order);
-        $this->assertEquals(3, $cards[0]->order);
-        $this->assertEquals(4, $cards[2]->order);
-
-        $response = $this->postJson('/api/v1/cards/' . $cards[2]->id . '/order', ['after' => $card->id]);
-
-        $card->refresh();
-        $cards = $cards->fresh();
-
-        $response
-            ->assertOk()
-            ->assertJson((new CardResource($cards[2]))->response()->getData(true));
-        $this->assertEquals(1, $cards[1]->order);
-        $this->assertEquals(2, $card->order);
-        $this->assertEquals(3, $cards[2]->order);
-        $this->assertEquals(4, $cards[0]->order);
-    }
-    public function test_can_change_order_to_bottom()
-    {
-        $team = Team::factory()->create();
-        $project = Project::factory()->team($team)->create();
-        $board = Board::factory()->project($project)->create();
-        $column = Column::factory()->board($board)->create();
-
-        $card = Card::factory()->column($column)->order(1)->create();
-        $cards = Card::factory(3)->column($column)
-            ->state(new Sequence(
-                ['order' => 2],
-                ['order' => 3],
-                ['order' => 4],
-            ))->create();
-
-        $user = User::factory()->hasAttached($team)->create();
-        Sanctum::actingAs($user);
-
-        $response = $this->postJson('/api/v1/cards/' . $card->id . '/order', ['after' => $cards[1]->id]);
-
-        $card->refresh();
-        $cards = $cards->fresh();
-
-        $response
-            ->assertOk()
-            ->assertJson((new CardResource($card))->response()->getData(true));
-        $this->assertEquals(1, $cards[0]->order);
-        $this->assertEquals(2, $cards[1]->order);
-        $this->assertEquals(3, $card->order);
-        $this->assertEquals(4, $cards[2]->order);
-
+        // Move to bottom direction
         $response = $this->postJson('/api/v1/cards/' . $card->id . '/order', ['after' => $cards[2]->id]);
 
         $card->refresh();
         $cards = $cards->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new CardResource($card))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $cards[0]->order);
         $this->assertEquals(2, $cards[1]->order);
         $this->assertEquals(3, $cards[2]->order);
         $this->assertEquals(4, $card->order);
-
-        $response = $this->postJson('/api/v1/cards/' . $card->id . '/order', ['after' => $cards[0]->id]);
-
-        $card->refresh();
-        $cards = $cards->fresh();
-
-        $response
-            ->assertOk()
-            ->assertJson((new CardResource($card))->response()->getData(true));
-        $this->assertEquals(1, $cards[0]->order);
-        $this->assertEquals(2, $card->order);
-        $this->assertEquals(3, $cards[1]->order);
-        $this->assertEquals(4, $cards[2]->order);
-
-        $response = $this->postJson('/api/v1/cards/' . $cards[0]->id . '/order', ['after' => $cards[2]->id]);
-
-        $card->refresh();
-        $cards = $cards->fresh();
-
-        $response
-            ->assertOk()
-            ->assertJson((new CardResource($cards[0]))->response()->getData(true));
-        $this->assertEquals(1, $card->order);
-        $this->assertEquals(2, $cards[1]->order);
-        $this->assertEquals(3, $cards[2]->order);
-        $this->assertEquals(4, $cards[0]->order);
     }
 
     public function test_cant_move_without_permissions()

--- a/tests/Feature/Api/V1/Column/ColumnControllerTest.php
+++ b/tests/Feature/Api/V1/Column/ColumnControllerTest.php
@@ -258,58 +258,6 @@ class ColumnControllerTest extends TestCase
         $this->assertEquals(3, $columns[2]->order);
         $this->assertEquals(4, $columns[0]->order);
     }
-    public function test_order_not_recalculated_with_inconsistent_order_on_ordering_to_up()
-    {
-        $team = Team::factory()->create();
-        $project = Project::factory()->team($team)->create();
-        $board = Board::factory()->project($project)->create();
-
-        $columns = Column::factory(2)->board($board)
-            ->state(new Sequence(
-                ['order' => 1],
-                ['order' => 3],
-            ))->create();
-        $column = Column::factory()->board($board)->order(4)->create();
-
-        $user = User::factory()->hasAttached($team)->create();
-        Sanctum::actingAs($user);
-
-        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[0]->id]);
-
-        $column->refresh();
-        $columns = $columns->fresh();
-
-        $response->assertNoContent();
-        $this->assertEquals(1, $columns[0]->order);
-        $this->assertEquals(2, $column->order);
-        $this->assertEquals(3, $columns[1]->order);
-    }
-    public function test_order_not_recalculated_with_inconsistent_order_on_ordering_to_bottom()
-    {
-        $team = Team::factory()->create();
-        $project = Project::factory()->team($team)->create();
-        $board = Board::factory()->project($project)->create();
-
-        $column = Column::factory()->board($board)->order(1)->create();
-        $columns = Column::factory(2)->board($board)
-        ->state(new Sequence(
-            ['order' => 2],
-            ['order' => 4],
-        ))->create();
-
-        $user = User::factory()->hasAttached($team)->create();
-        Sanctum::actingAs($user);
-
-        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[0]->id]);
-
-        $column->refresh();
-        $columns = $columns->fresh();
-
-        $response->assertNoContent();
-        $this->assertEquals(1, $columns[0]->order);
-        $this->assertEquals(2, $column->order);
-        $this->assertEquals(3, $columns[1]->order);
-    }
 
     public function test_cant_delete_without_permissions()
     {

--- a/tests/Feature/Api/V1/Column/ColumnControllerTest.php
+++ b/tests/Feature/Api/V1/Column/ColumnControllerTest.php
@@ -138,7 +138,7 @@ class ColumnControllerTest extends TestCase
             ->assertUnprocessable()
             ->assertJsonValidationErrors(['after' => 'The selected after is invalid.']);
     }
-    public function test_can_change_order_to_up()
+    public function test_can_change_order()
     {
         $team = Team::factory()->create();
         $project = Project::factory()->team($team)->create();
@@ -154,6 +154,7 @@ class ColumnControllerTest extends TestCase
         $user = User::factory()->hasAttached($team)->create();
         Sanctum::actingAs($user);
 
+        // Move to up dirrection
         $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[1]->id]);
 
         $column->refresh();
@@ -165,6 +166,7 @@ class ColumnControllerTest extends TestCase
         $this->assertEquals(3, $column->order);
         $this->assertEquals(4, $columns[2]->order);
 
+        // First position
         $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => 0]);
 
         $column->refresh();
@@ -176,55 +178,7 @@ class ColumnControllerTest extends TestCase
         $this->assertEquals(3, $columns[1]->order);
         $this->assertEquals(4, $columns[2]->order);
 
-        $response = $this->postJson('/api/v1/columns/' . $columns[1]->id . '/order', ['after' => 0]);
-
-        $column->refresh();
-        $columns = $columns->fresh();
-
-        $response->assertNoContent();
-        $this->assertEquals(1, $columns[1]->order);
-        $this->assertEquals(2, $column->order);
-        $this->assertEquals(3, $columns[0]->order);
-        $this->assertEquals(4, $columns[2]->order);
-
-        $response = $this->postJson('/api/v1/columns/' . $columns[2]->id . '/order', ['after' => $column->id]);
-
-        $column->refresh();
-        $columns = $columns->fresh();
-
-        $response->assertNoContent();
-        $this->assertEquals(1, $columns[1]->order);
-        $this->assertEquals(2, $column->order);
-        $this->assertEquals(3, $columns[2]->order);
-        $this->assertEquals(4, $columns[0]->order);
-    }
-    public function test_can_change_order_to_bottom()
-    {
-        $team = Team::factory()->create();
-        $project = Project::factory()->team($team)->create();
-        $board = Board::factory()->project($project)->create();
-        $column = Column::factory()->board($board)->order(1)->create();
-        $columns = Column::factory(3)->board($board)
-            ->state(new Sequence(
-                ['order' => 2],
-                ['order' => 3],
-                ['order' => 4],
-            ))->create();
-
-        $user = User::factory()->hasAttached($team)->create();
-        Sanctum::actingAs($user);
-
-        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[1]->id]);
-
-        $column->refresh();
-        $columns = $columns->fresh();
-
-        $response->assertNoContent();
-        $this->assertEquals(1, $columns[0]->order);
-        $this->assertEquals(2, $columns[1]->order);
-        $this->assertEquals(3, $column->order);
-        $this->assertEquals(4, $columns[2]->order);
-
+        // Move to bottom direction
         $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[2]->id]);
 
         $column->refresh();
@@ -235,28 +189,6 @@ class ColumnControllerTest extends TestCase
         $this->assertEquals(2, $columns[1]->order);
         $this->assertEquals(3, $columns[2]->order);
         $this->assertEquals(4, $column->order);
-
-        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[0]->id]);
-
-        $column->refresh();
-        $columns = $columns->fresh();
-
-        $response->assertNoContent();
-        $this->assertEquals(1, $columns[0]->order);
-        $this->assertEquals(2, $column->order);
-        $this->assertEquals(3, $columns[1]->order);
-        $this->assertEquals(4, $columns[2]->order);
-
-        $response = $this->postJson('/api/v1/columns/' . $columns[0]->id . '/order', ['after' => $columns[2]->id]);
-
-        $column->refresh();
-        $columns = $columns->fresh();
-
-        $response->assertNoContent();
-        $this->assertEquals(1, $column->order);
-        $this->assertEquals(2, $columns[1]->order);
-        $this->assertEquals(3, $columns[2]->order);
-        $this->assertEquals(4, $columns[0]->order);
     }
 
     public function test_cant_delete_without_permissions()

--- a/tests/Feature/Api/V1/Column/ColumnControllerTest.php
+++ b/tests/Feature/Api/V1/Column/ColumnControllerTest.php
@@ -159,9 +159,7 @@ class ColumnControllerTest extends TestCase
         $column->refresh();
         $columns = $columns->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $columns[0]->order);
         $this->assertEquals(2, $columns[1]->order);
         $this->assertEquals(3, $column->order);
@@ -172,9 +170,7 @@ class ColumnControllerTest extends TestCase
         $column->refresh();
         $columns = $columns->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $column->order);
         $this->assertEquals(2, $columns[0]->order);
         $this->assertEquals(3, $columns[1]->order);
@@ -185,9 +181,7 @@ class ColumnControllerTest extends TestCase
         $column->refresh();
         $columns = $columns->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new ColumnResource($columns[1]))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $columns[1]->order);
         $this->assertEquals(2, $column->order);
         $this->assertEquals(3, $columns[0]->order);
@@ -198,9 +192,7 @@ class ColumnControllerTest extends TestCase
         $column->refresh();
         $columns = $columns->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new ColumnResource($columns[2]))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $columns[1]->order);
         $this->assertEquals(2, $column->order);
         $this->assertEquals(3, $columns[2]->order);
@@ -227,9 +219,7 @@ class ColumnControllerTest extends TestCase
         $column->refresh();
         $columns = $columns->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $columns[0]->order);
         $this->assertEquals(2, $columns[1]->order);
         $this->assertEquals(3, $column->order);
@@ -240,9 +230,7 @@ class ColumnControllerTest extends TestCase
         $column->refresh();
         $columns = $columns->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $columns[0]->order);
         $this->assertEquals(2, $columns[1]->order);
         $this->assertEquals(3, $columns[2]->order);
@@ -253,9 +241,7 @@ class ColumnControllerTest extends TestCase
         $column->refresh();
         $columns = $columns->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $columns[0]->order);
         $this->assertEquals(2, $column->order);
         $this->assertEquals(3, $columns[1]->order);
@@ -266,9 +252,7 @@ class ColumnControllerTest extends TestCase
         $column->refresh();
         $columns = $columns->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new ColumnResource($columns[0]))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $column->order);
         $this->assertEquals(2, $columns[1]->order);
         $this->assertEquals(3, $columns[2]->order);
@@ -295,9 +279,7 @@ class ColumnControllerTest extends TestCase
         $column->refresh();
         $columns = $columns->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $columns[0]->order);
         $this->assertEquals(2, $column->order);
         $this->assertEquals(3, $columns[1]->order);
@@ -323,9 +305,7 @@ class ColumnControllerTest extends TestCase
         $column->refresh();
         $columns = $columns->fresh();
 
-        $response
-            ->assertOk()
-            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $response->assertNoContent();
         $this->assertEquals(1, $columns[0]->order);
         $this->assertEquals(2, $column->order);
         $this->assertEquals(3, $columns[1]->order);

--- a/tests/Feature/Api/V1/Column/ColumnControllerTest.php
+++ b/tests/Feature/Api/V1/Column/ColumnControllerTest.php
@@ -8,6 +8,7 @@ use App\Models\Column;
 use App\Models\Project;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
@@ -77,6 +78,257 @@ class ColumnControllerTest extends TestCase
             ->assertOk()
             ->assertJson((new ColumnResource(Column::first()))->response()->getData(true));
         $this->assertDatabaseHas('columns', ['board_id' => $board->id] + $data);
+    }
+
+    public function test_cant_change_order_without_permissions()
+    {
+        $team = Team::factory()->create();
+        $project = Project::factory()->team($team)->create();
+        $board = Board::factory()->project($project)->create();
+        $column = Column::factory()->board($board)->create();
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order');
+
+        $response->assertForbidden();
+    }
+    public function test_cant_change_order_with_incorrect_request()
+    {
+        $team = Team::factory()->create();
+        $project = Project::factory()->team($team)->create();
+        $board = Board::factory()->project($project)->create();
+        Column::factory()->board($board)
+            ->state(new Sequence(
+                ['order' => 1],
+                ['order' => 2],
+                ['order' => 3],
+            ))->create();
+
+        $column = Column::factory()->board($board)->order(4)->create();
+
+        $user = User::factory()->hasAttached($team)->create();
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order');
+
+        $response
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['after']);
+    }
+    public function test_cant_change_order_after_card_in_other_column()
+    {
+        $team = Team::factory()->create();
+        $project = Project::factory()->team($team)->create();
+        $board = Board::factory()->project($project)->create();
+        $columns = Column::factory(3)->board($board)
+            ->state(new Sequence(
+                ['order' => 1],
+                ['order' => 2],
+                ['order' => 3],
+            ))->create();
+
+        $column = Column::factory()->board(Board::factory()->project($project))->order(4)->create();
+
+        $user = User::factory()->hasAttached($team)->create();
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[0]->id]);
+        $response
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['after' => 'The selected after is invalid.']);
+    }
+    public function test_can_change_order_to_up()
+    {
+        $team = Team::factory()->create();
+        $project = Project::factory()->team($team)->create();
+        $board = Board::factory()->project($project)->create();
+        $columns = Column::factory(3)->board($board)
+            ->state(new Sequence(
+                ['order' => 1],
+                ['order' => 2],
+                ['order' => 3],
+            ))->create();
+        $column = Column::factory()->board($board)->order(4)->create();
+
+        $user = User::factory()->hasAttached($team)->create();
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[1]->id]);
+
+        $column->refresh();
+        $columns = $columns->fresh();
+
+        $response
+            ->assertOk()
+            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $this->assertEquals(1, $columns[0]->order);
+        $this->assertEquals(2, $columns[1]->order);
+        $this->assertEquals(3, $column->order);
+        $this->assertEquals(4, $columns[2]->order);
+
+        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => 0]);
+
+        $column->refresh();
+        $columns = $columns->fresh();
+
+        $response
+            ->assertOk()
+            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $this->assertEquals(1, $column->order);
+        $this->assertEquals(2, $columns[0]->order);
+        $this->assertEquals(3, $columns[1]->order);
+        $this->assertEquals(4, $columns[2]->order);
+
+        $response = $this->postJson('/api/v1/columns/' . $columns[1]->id . '/order', ['after' => 0]);
+
+        $column->refresh();
+        $columns = $columns->fresh();
+
+        $response
+            ->assertOk()
+            ->assertJson((new ColumnResource($columns[1]))->response()->getData(true));
+        $this->assertEquals(1, $columns[1]->order);
+        $this->assertEquals(2, $column->order);
+        $this->assertEquals(3, $columns[0]->order);
+        $this->assertEquals(4, $columns[2]->order);
+
+        $response = $this->postJson('/api/v1/columns/' . $columns[2]->id . '/order', ['after' => $column->id]);
+
+        $column->refresh();
+        $columns = $columns->fresh();
+
+        $response
+            ->assertOk()
+            ->assertJson((new ColumnResource($columns[2]))->response()->getData(true));
+        $this->assertEquals(1, $columns[1]->order);
+        $this->assertEquals(2, $column->order);
+        $this->assertEquals(3, $columns[2]->order);
+        $this->assertEquals(4, $columns[0]->order);
+    }
+    public function test_can_change_order_to_bottom()
+    {
+        $team = Team::factory()->create();
+        $project = Project::factory()->team($team)->create();
+        $board = Board::factory()->project($project)->create();
+        $column = Column::factory()->board($board)->order(1)->create();
+        $columns = Column::factory(3)->board($board)
+            ->state(new Sequence(
+                ['order' => 2],
+                ['order' => 3],
+                ['order' => 4],
+            ))->create();
+
+        $user = User::factory()->hasAttached($team)->create();
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[1]->id]);
+
+        $column->refresh();
+        $columns = $columns->fresh();
+
+        $response
+            ->assertOk()
+            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $this->assertEquals(1, $columns[0]->order);
+        $this->assertEquals(2, $columns[1]->order);
+        $this->assertEquals(3, $column->order);
+        $this->assertEquals(4, $columns[2]->order);
+
+        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[2]->id]);
+
+        $column->refresh();
+        $columns = $columns->fresh();
+
+        $response
+            ->assertOk()
+            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $this->assertEquals(1, $columns[0]->order);
+        $this->assertEquals(2, $columns[1]->order);
+        $this->assertEquals(3, $columns[2]->order);
+        $this->assertEquals(4, $column->order);
+
+        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[0]->id]);
+
+        $column->refresh();
+        $columns = $columns->fresh();
+
+        $response
+            ->assertOk()
+            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $this->assertEquals(1, $columns[0]->order);
+        $this->assertEquals(2, $column->order);
+        $this->assertEquals(3, $columns[1]->order);
+        $this->assertEquals(4, $columns[2]->order);
+
+        $response = $this->postJson('/api/v1/columns/' . $columns[0]->id . '/order', ['after' => $columns[2]->id]);
+
+        $column->refresh();
+        $columns = $columns->fresh();
+
+        $response
+            ->assertOk()
+            ->assertJson((new ColumnResource($columns[0]))->response()->getData(true));
+        $this->assertEquals(1, $column->order);
+        $this->assertEquals(2, $columns[1]->order);
+        $this->assertEquals(3, $columns[2]->order);
+        $this->assertEquals(4, $columns[0]->order);
+    }
+    public function test_order_not_recalculated_with_inconsistent_order_on_ordering_to_up()
+    {
+        $team = Team::factory()->create();
+        $project = Project::factory()->team($team)->create();
+        $board = Board::factory()->project($project)->create();
+
+        $columns = Column::factory(2)->board($board)
+            ->state(new Sequence(
+                ['order' => 1],
+                ['order' => 3],
+            ))->create();
+        $column = Column::factory()->board($board)->order(4)->create();
+
+        $user = User::factory()->hasAttached($team)->create();
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[0]->id]);
+
+        $column->refresh();
+        $columns = $columns->fresh();
+
+        $response
+            ->assertOk()
+            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $this->assertEquals(1, $columns[0]->order);
+        $this->assertEquals(2, $column->order);
+        $this->assertEquals(3, $columns[1]->order);
+    }
+    public function test_order_not_recalculated_with_inconsistent_order_on_ordering_to_bottom()
+    {
+        $team = Team::factory()->create();
+        $project = Project::factory()->team($team)->create();
+        $board = Board::factory()->project($project)->create();
+
+        $column = Column::factory()->board($board)->order(1)->create();
+        $columns = Column::factory(2)->board($board)
+        ->state(new Sequence(
+            ['order' => 2],
+            ['order' => 4],
+        ))->create();
+
+        $user = User::factory()->hasAttached($team)->create();
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/v1/columns/' . $column->id . '/order', ['after' => $columns[0]->id]);
+
+        $column->refresh();
+        $columns = $columns->fresh();
+
+        $response
+            ->assertOk()
+            ->assertJson((new ColumnResource($column))->response()->getData(true));
+        $this->assertEquals(1, $columns[0]->order);
+        $this->assertEquals(2, $column->order);
+        $this->assertEquals(3, $columns[1]->order);
     }
 
     public function test_cant_delete_without_permissions()

--- a/tests/Feature/Traits/HasOrder/EloquentHasOrderIntegrationTest.php
+++ b/tests/Feature/Traits/HasOrder/EloquentHasOrderIntegrationTest.php
@@ -101,7 +101,7 @@ class EloquentHasOrderIntegrationTest extends TestCase
         $this->assertEquals(4, $models[0]->order);
     }
 
-    public function test_move_after_method_up()
+    public function test_move_after_method_to_top_direction()
     {
         $models = $this->createModels();
         $models[2]->moveAfter($models[0]);
@@ -116,7 +116,7 @@ class EloquentHasOrderIntegrationTest extends TestCase
         $this->assertEquals(2, $models[2]->order);
         $this->assertEquals(3, $models[1]->order);
     }
-    public function test_move_after_method_bottom()
+    public function test_move_after_method_to_bottom_direction()
     {
         $models = $this->createModels();
         $models[0]->moveAfter($models[1]);


### PR DESCRIPTION
This PR adds ability to set column order.

We can pass `after_column` parameters on **store** endpoint.

Also, we can use dedicated endpoint to set new column order.